### PR TITLE
Randomize tokens correctly

### DIFF
--- a/src/game/Board.java
+++ b/src/game/Board.java
@@ -88,8 +88,6 @@ public class Board {
 
 		hexboard.add(new Hex(HexType.desert));
 
-		System.out.println(hexboard.size());
-
 		Collections.shuffle(hexboard);
 
 	}
@@ -114,16 +112,11 @@ public class Board {
 		tokenboard.add(new Token(6, 'P'));
 		tokenboard.add(new Token(3, 'Q'));
 		tokenboard.add(new Token(11, 'R'));
+		// This is the desert hex token - essentially a blank token
+		tokenboard.add(new Token(0, 'Z'));
+		
+		Collections.shuffle(tokenboard);
 
-	}
-
-	public void tokenassignment() {
-		for (int i = 0; i < hexboard.size(); i++) {
-			if (hexboard.get(i).getHexType() == HexType.desert) {
-				tokenboard.set(i, null);
-			}
-
-		}
 	}
 
 	public ArrayList<Token> getTokenboard() {

--- a/src/game/Board.java
+++ b/src/game/Board.java
@@ -93,30 +93,40 @@ public class Board {
 	}
 
 	public void initializetokens() {
-
-		tokenboard.add(new Token(5, 'A'));
-		tokenboard.add(new Token(2, 'B'));
-		tokenboard.add(new Token(6, 'C'));
-		tokenboard.add(new Token(3, 'D'));
-		tokenboard.add(new Token(8, 'E'));
-		tokenboard.add(new Token(10, 'F'));
-		tokenboard.add(new Token(9, 'G'));
-		tokenboard.add(new Token(12, 'H'));
-		tokenboard.add(new Token(11, 'I'));
-		tokenboard.add(new Token(4, 'J'));
-		tokenboard.add(new Token(8, 'K'));
-		tokenboard.add(new Token(10, 'L'));
-		tokenboard.add(new Token(9, 'M'));
-		tokenboard.add(new Token(4, 'N'));
-		tokenboard.add(new Token(5, 'O'));
-		tokenboard.add(new Token(6, 'P'));
-		tokenboard.add(new Token(3, 'Q'));
-		tokenboard.add(new Token(11, 'R'));
-		// This is the desert hex token - essentially a blank token
-		tokenboard.add(new Token(0, 'Z'));
+		ArrayList<Token> listOfTokens = new ArrayList<>();
 		
-		Collections.shuffle(tokenboard);
+		listOfTokens.add(new Token(5, 'A'));
+		listOfTokens.add(new Token(2, 'B'));
+		listOfTokens.add(new Token(6, 'C'));
+		listOfTokens.add(new Token(3, 'D'));
+		listOfTokens.add(new Token(8, 'E'));
+		listOfTokens.add(new Token(10, 'F'));
+		listOfTokens.add(new Token(9, 'G'));
+		listOfTokens.add(new Token(12, 'H'));
+		listOfTokens.add(new Token(11, 'I'));
+		listOfTokens.add(new Token(4, 'J'));
+		listOfTokens.add(new Token(8, 'K'));
+		listOfTokens.add(new Token(10, 'L'));
+		listOfTokens.add(new Token(9, 'M'));
+		listOfTokens.add(new Token(4, 'N'));
+		listOfTokens.add(new Token(5, 'O'));
+		listOfTokens.add(new Token(6, 'P'));
+		listOfTokens.add(new Token(3, 'Q'));
+		listOfTokens.add(new Token(11, 'R'));
+		Token desertToken = new Token(0, 'Z');
+		
+		Collections.shuffle(listOfTokens);
 
+		for (int i = 0; i < hexboard.size(); i++) {
+			if (hexboard.get(i).getHexType() != HexType.desert) {
+				tokenboard.add(i, listOfTokens.get(i));
+			} else {
+				tokenboard.add(i, desertToken);
+				// We need to add this to the listOfTokens as well,
+				// so the lists stay the same size
+				listOfTokens.add(i, desertToken);
+			}
+		}
 	}
 
 	public ArrayList<Token> getTokenboard() {

--- a/src/gui/TokenLayer.java
+++ b/src/gui/TokenLayer.java
@@ -4,7 +4,6 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.imageio.ImageIO;

--- a/src/gui/TokenLayer.java
+++ b/src/gui/TokenLayer.java
@@ -11,6 +11,8 @@ import javax.imageio.ImageIO;
 import javax.swing.JComponent;
 import javax.swing.plaf.LayerUI;
 
+import game.Token;
+
 /**
  * @author cauth0n
  */
@@ -18,9 +20,10 @@ import javax.swing.plaf.LayerUI;
 public class TokenLayer extends LayerUI<JComponent> {
 
 	private final double scaleFactor = 0.20;
+	private List<Token> tokens;
 
-	public TokenLayer() {
-		readTokenImages();
+	public TokenLayer(List<Token> tokens) {
+		this.tokens = tokens;
 	}
 
 	public void paint(Graphics g, JComponent c) {
@@ -32,57 +35,58 @@ public class TokenLayer extends LayerUI<JComponent> {
 
 	public void buildClassicTokens(Graphics2D g2d) {
 
-		List<Image> tokens = readTokenImages();
 		int imageWidth = 150;
 		int imageHeight = imageWidth + 25;
 		int initialX = Window.borderSize + 200;
 		int initialY = Window.borderSize + 50;
 
 		// First level 3 hexes (row)
-		g2d.drawImage(tokens.get(0), initialX, initialY, null);
-		g2d.drawImage(tokens.get(1), initialX + imageWidth, initialY, null);
-		g2d.drawImage(tokens.get(2), initialX + 2 * imageWidth, initialY, null);
+		g2d.drawImage(readTokenImages(tokens.get(0)), initialX, initialY, null);
+		g2d.drawImage(readTokenImages(tokens.get(1)), initialX + imageWidth, initialY, null);
+		g2d.drawImage(readTokenImages(tokens.get(2)), initialX + 2 * imageWidth, initialY, null);
 
 		// Second level 4 hexes (row)
 		int level2Y = initialY + 3 * (imageHeight / 4);
-		g2d.drawImage(tokens.get(3), initialX - (imageWidth / 2), level2Y, null);
-		g2d.drawImage(tokens.get(4), initialX + (imageWidth / 2), level2Y, null);
-		g2d.drawImage(tokens.get(5), initialX + 3 * (imageWidth / 2), level2Y, null);
-		g2d.drawImage(tokens.get(6), initialX + 5 * (imageWidth / 2), level2Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(3)), initialX - (imageWidth / 2), level2Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(4)), initialX + (imageWidth / 2), level2Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(5)), initialX + 3 * (imageWidth / 2), level2Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(6)), initialX + 5 * (imageWidth / 2), level2Y, null);
 
 		// Third level; 5 hexes (row)
 		int level3Y = initialY + 3 * (imageHeight / 2);
-		g2d.drawImage(tokens.get(7), initialX - imageWidth, level3Y, null);
-		g2d.drawImage(tokens.get(8), initialX, level3Y, null);
-		g2d.drawImage(tokens.get(9), initialX + imageWidth, level3Y, null);
-		g2d.drawImage(tokens.get(10), initialX + 2 * imageWidth, level3Y, null);
-		g2d.drawImage(tokens.get(11), initialX + 3 * imageWidth, level3Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(7)), initialX - imageWidth, level3Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(8)), initialX, level3Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(9)), initialX + imageWidth, level3Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(10)), initialX + 2 * imageWidth, level3Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(11)), initialX + 3 * imageWidth, level3Y, null);
 
 		// Fourth level; 4 hexes (row)
 		int level4Y = initialY + 9 * (imageHeight / 4);
-		g2d.drawImage(tokens.get(12), initialX - (imageWidth / 2), level4Y, null);
-		g2d.drawImage(tokens.get(13), initialX + (imageWidth / 2), level4Y, null);
-		g2d.drawImage(tokens.get(14), initialX + 3 * (imageWidth / 2), level4Y, null);
-		g2d.drawImage(tokens.get(15), initialX + 5 * (imageWidth / 2), level4Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(12)), initialX - (imageWidth / 2), level4Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(13)), initialX + (imageWidth / 2), level4Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(14)), initialX + 3 * (imageWidth / 2), level4Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(15)), initialX + 5 * (imageWidth / 2), level4Y, null);
 
 		// Fifth level 3 hexes (row)
 		int level5Y = initialY + 3 * imageHeight;
-		g2d.drawImage(tokens.get(16), initialX, level5Y, null);
-		g2d.drawImage(tokens.get(17), initialX + imageWidth, level5Y, null);
-		//g2d.drawImage(tokens.get(18), initialX + 2 * imageWidth, level5Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(16)), initialX, level5Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(17)), initialX + imageWidth, level5Y, null);
+		g2d.drawImage(readTokenImages(tokens.get(18)), initialX + 2 * imageWidth, level5Y, null);
 	}
 
-	public List<Image> readTokenImages() {
-		List<Image> tokenImages = new ArrayList<>();
+	public Image readTokenImages(Token token) {
+		Image tokenImage = null;
+		
 		try {
-			for (char c = 'A'; c <= 'R'; c++) {
-				tokenImages.add(Window.scaleImage(ImageIO.read(new File("graphics/tokens/" + c + ".png")), scaleFactor));
+			if (token.getLetter() == 'Z') {
+				tokenImage = null;
+			} else {
+				tokenImage = Window.scaleImage(ImageIO.read(new File("graphics/tokens/" + token.getLetter() + ".png")), scaleFactor);
 			}
-
 		} catch (Exception e) {
 			System.out.println("Could not find token images");
 		}
-
-		return tokenImages;
+		
+		return tokenImage;
 	}
 }

--- a/src/gui/Window.java
+++ b/src/gui/Window.java
@@ -34,7 +34,7 @@ public class Window {
 
 		JPanel hexes = new HexPanel(gameBoard.getHexboard());
 
-		LayerUI<JComponent> layerUI = new TokenLayer();
+		LayerUI<JComponent> layerUI = new TokenLayer(gameBoard.getTokenboard());
 		JLayer<JComponent> jLayer = new JLayer<JComponent>(hexes, layerUI);
 
 		frame.add(jLayer);

--- a/src/gui/Window.java
+++ b/src/gui/Window.java
@@ -21,7 +21,7 @@ public class Window {
 	public final static int borderSize = 25;
 
 	public Window(Board gameBoard) {
-		frame = new JFrame("CATAN DOOOD");
+		frame = new JFrame("Settlers of Catan");
 		frame.setSize(windowWidth, windowHeight);
 
 		buidlClassicLayeredPanel(gameBoard);
@@ -33,7 +33,6 @@ public class Window {
 	public void buidlClassicLayeredPanel(Board gameBoard) {
 
 		JPanel hexes = new HexPanel(gameBoard.getHexboard());
-
 		LayerUI<JComponent> layerUI = new TokenLayer(gameBoard.getTokenboard());
 		JLayer<JComponent> jLayer = new JLayer<JComponent>(hexes, layerUI);
 


### PR DESCRIPTION
### Issue

The tokens were just being placed down as A-R and weren't being randomized. They also weren't skipping the desert.
### Fix

I added a specific "null" desert token that is added to the desert hex. This allows all the ArrayLists to remain the same size so Java doesn't have a fit.
